### PR TITLE
SwiftUI徹底入門Chapter7

### DIFF
--- a/Tapioca milk tea.xcodeproj/project.pbxproj
+++ b/Tapioca milk tea.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		C601FAFE253DD0C000E38217 /* CategoryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C601FAFD253DD0C000E38217 /* CategoryRow.swift */; };
 		C601FB00253DD23400E38217 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C601FAFF253DD23400E38217 /* HomeView.swift */; };
 		C601FB03253F2B5B00E38217 /* TapiocaTeaView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C601FB02253F2B5B00E38217 /* TapiocaTeaView.swift */; };
+		C601FB052540B0C600E38217 /* ShopImge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C601FB042540B0C600E38217 /* ShopImge.swift */; };
+		C601FB072540B25C00E38217 /* ShopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C601FB062540B25C00E38217 /* ShopView.swift */; };
 		C669B14C253D8F2F009DC8CE /* Special.swift in Sources */ = {isa = PBXBuildFile; fileRef = C669B14B253D8F2F009DC8CE /* Special.swift */; };
 		C6B5E7E424F434A500708C40 /* OrderDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B5E7E324F434A500708C40 /* OrderDetail.swift */; };
 		C6B5E7E824FCB81B00708C40 /* OrderRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B5E7E724FCB81B00708C40 /* OrderRowView.swift */; };
@@ -46,6 +48,8 @@
 		C601FAFD253DD0C000E38217 /* CategoryRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRow.swift; sourceTree = "<group>"; };
 		C601FAFF253DD23400E38217 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		C601FB02253F2B5B00E38217 /* TapiocaTeaView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapiocaTeaView.swift; sourceTree = "<group>"; };
+		C601FB042540B0C600E38217 /* ShopImge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopImge.swift; sourceTree = "<group>"; };
+		C601FB062540B25C00E38217 /* ShopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopView.swift; sourceTree = "<group>"; };
 		C669B14B253D8F2F009DC8CE /* Special.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Special.swift; sourceTree = "<group>"; };
 		C6B5E7E324F434A500708C40 /* OrderDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetail.swift; sourceTree = "<group>"; };
 		C6B5E7E724FCB81B00708C40 /* OrderRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderRowView.swift; sourceTree = "<group>"; };
@@ -132,6 +136,8 @@
 				C6B5E7E324F434A500708C40 /* OrderDetail.swift */,
 				C6FFE149253C168500488118 /* OrderView.swift */,
 				C601FB02253F2B5B00E38217 /* TapiocaTeaView.swift */,
+				C601FB042540B0C600E38217 /* ShopImge.swift */,
+				C601FB062540B25C00E38217 /* ShopView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -215,6 +221,8 @@
 				C6FFE14A253C168500488118 /* OrderView.swift in Sources */,
 				C601FAFC253DCAE200E38217 /* ShopRow.swift in Sources */,
 				53F05E4522F3228C009E3AA8 /* OrderEntity.swift in Sources */,
+				C601FB052540B0C600E38217 /* ShopImge.swift in Sources */,
+				C601FB072540B25C00E38217 /* ShopView.swift in Sources */,
 				C6FFE14E253CAE5100488118 /* Shop.swift in Sources */,
 				53BB726D22E1C33C00AA7546 /* ContentView.swift in Sources */,
 				C601FAFE253DD0C000E38217 /* CategoryRow.swift in Sources */,

--- a/Tapioca milk tea/ContentView.swift
+++ b/Tapioca milk tea/ContentView.swift
@@ -3,7 +3,23 @@ import SwiftUI
 struct ContentView : View {
     
     var body: some View {
-        OrderView()
+        TabView {
+            HomeView()
+                .tabItem {
+                    Image(systemName: "house.fill")
+                    Text("Home")
+                }
+            OrderView()
+                .tabItem {
+                    Image(systemName: "textbox")
+                    Text("ORDER")
+                }
+            OrderHistoryView()
+                .tabItem {
+                    Image(systemName: "list.bullet")
+                    Text("LIST")
+                }
+        }
     }
 }
 

--- a/Tapioca milk tea/Views/HomeView.swift
+++ b/Tapioca milk tea/Views/HomeView.swift
@@ -19,14 +19,17 @@ struct HomeView: View {
     }
 
     var body: some View {
-        ScrollView {
-            ShopRow(shops: dataStore.shops)
+        NavigationView {
+            ScrollView {
+                ShopRow(shops: dataStore.shops)
 
-            ForEach(categories.keys.sorted(),
-                    id: \.self) { key in
-                CategoryRow(categoryName: key,
-                         items: self.categories[key]!)
+                ForEach(categories.keys.sorted(),
+                        id: \.self) { key in
+                    CategoryRow(categoryName: key,
+                                items: self.categories[key]!)
+                }
             }
+            .navigationBarTitle(Text("Home"))
         }
     }
 }

--- a/Tapioca milk tea/Views/OrderDetail.swift
+++ b/Tapioca milk tea/Views/OrderDetail.swift
@@ -56,6 +56,7 @@ struct OrderDetail: View {
             Text(self.dateFormatter.string(from: order.date))
                 .font(.caption)
         }
+        .navigationBarTitle("Order Detail")
     }
 }
 

--- a/Tapioca milk tea/Views/OrderHistoryView.swift
+++ b/Tapioca milk tea/Views/OrderHistoryView.swift
@@ -9,11 +9,25 @@
 import SwiftUI
 
 struct OrderHistoryView: View {
+    @State var showFavoritesOnly = false
+
     var body: some View {
-        List {
-            ForEach(orderStore.orders) { order in
-                OrderRowView(order: order)
+        NavigationView {
+            List {
+                Toggle(isOn: $showFavoritesOnly, label: {
+                    Text("Favorites only")
+                })
+                .padding(EdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 20))
+
+                ForEach(orderStore.orders) { order in
+                    if !self.showFavoritesOnly || order.favorite {
+                        NavigationLink(destination: OrderDetail(order: order)) {
+                            OrderRowView(order: order)
+                        }
+                    }
+                }
             }
+            .navigationBarTitle("Order List")
         }
     }
 }

--- a/Tapioca milk tea/Views/OrderView.swift
+++ b/Tapioca milk tea/Views/OrderView.swift
@@ -24,9 +24,9 @@ struct OrderView: View {
         ScrollView {
             VStack {
 
-                TapiocaTeaView(iceCream: Int(order.iceCream),
-                               flavor: Int(order.flavor),
-                               nataDeCoco: order.nataDeCoco)
+                TapiocaTeaView(iceCream: Int(iceCream),
+                               flavor: Int(flavor),
+                               nataDeCoco: nataDeCoco)
                     .frame(width: 350, height: 350)
 
                 HStack {

--- a/Tapioca milk tea/Views/ShopImge.swift
+++ b/Tapioca milk tea/Views/ShopImge.swift
@@ -1,0 +1,43 @@
+//
+//  ShopImge.swift
+//  Tapioca milk tea
+//
+//  Created by 中村裕紀 on 2020/10/22.
+//  Copyright © 2020 example.com. All rights reserved.
+//
+
+import SwiftUI
+
+// 外側の線のグラデーション
+fileprivate let gradient = Gradient(colors: [
+    .white,
+    Color.init(red: 0.9, green: 0.9, blue: 0.9)
+])
+
+fileprivate let linear = LinearGradient(
+    gradient: gradient, startPoint: .top, endPoint: .bottom
+)
+
+struct ShopImage: View {
+    let image: Image
+
+    var body: some View {
+        image
+            .resizable()
+            .aspectRatio(contentMode: /*@START_MENU_TOKEN@*/.fill/*@END_MENU_TOKEN@*/)
+            .frame(width: 250, height: 250)
+            .clipShape(/*@START_MENU_TOKEN@*/Circle()/*@END_MENU_TOKEN@*/)
+            .overlay(Circle().stroke(linear, lineWidth: 13))
+    }
+}
+
+struct ShopImge_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            ForEach(dataStore.shops) { shop in
+                ShopImage(image: shop.image)
+            }
+        }
+        .previewLayout(.fixed(width: 300, height: 300))
+    }
+}

--- a/Tapioca milk tea/Views/ShopRow.swift
+++ b/Tapioca milk tea/Views/ShopRow.swift
@@ -8,6 +8,25 @@
 
 import SwiftUI
 
+struct ShopCell: View {
+    var shop: Shop
+
+    var body: some View {
+        VStack(alignment: .center) {
+            shop.image
+                .renderingMode(.original)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: 155, height: 155)
+                .clipShape(Circle())
+            Text(shop.name)
+                .foregroundColor(.black)
+                .font(.caption)
+        }
+        .padding()
+    }
+}
+
 struct ShopRow: View {
     var shops: [Shop]
 
@@ -21,19 +40,11 @@ struct ShopRow: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(alignment: .top, spacing: 0) {
                     ForEach(self.shops) { shop in
-                        VStack(alignment: .center) {
-                            shop.image
-                                .resizable()
-                                .aspectRatio(contentMode: .fill)
-                                .frame(width: 155, height: 155)
-                                .clipShape(/*@START_MENU_TOKEN@*/Circle()/*@END_MENU_TOKEN@*/)
-
-                            Text(shop.name)
-                                .font(.subheadline)
-                                .foregroundColor(.primary)
-                                .font(.caption)
-                        }
-                        .padding(.leading, 15)
+                        NavigationLink(
+                            destination: ShopView(shop: shop),
+                            label: {
+                                ShopCell(shop: shop)
+                            })
                     }
                 }
             }

--- a/Tapioca milk tea/Views/ShopView.swift
+++ b/Tapioca milk tea/Views/ShopView.swift
@@ -1,0 +1,39 @@
+//
+//  ShopView.swift
+//  Tapioca milk tea
+//
+//  Created by 中村裕紀 on 2020/10/22.
+//  Copyright © 2020 example.com. All rights reserved.
+//
+
+import SwiftUI
+
+struct ShopView: View {
+    var shop: Shop
+
+    var body: some View {
+        VStack {
+            Rectangle()
+            ShopImage(image: shop.image)
+                .padding(.top, -130)
+            Text(shop.name)
+                .padding()
+                .font(.largeTitle)
+            Text(shop.address)
+                .lineLimit(nil)
+                .multilineTextAlignment(.center)
+                .padding()
+            Text("Phone: " + shop.phoneNumber)
+                .padding()
+        }
+        .navigationBarTitle(shop.name)
+    }
+}
+
+struct ShopView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            ShopView(shop: dataStore.shops[2])
+        }
+    }
+}


### PR DESCRIPTION
#5
## 対応内容
- ナビゲーション  
  - NavigationView UIKitでいうところのUINavigationController。階層的な画面遷移を管理する。  
- シート  
  - modal遷移できるようになる sheetモディファイア。  
- タブ  
  - TabViewを使う。ViewBuilderを使ってImageとTextをクロージャ内で縦に並べタブバーに表示する内容をセットできる  
どれもiOSアプリにおいて重要なところかつ良く使いそうなところ。